### PR TITLE
chore: Bump the version and remove the IDE cap

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,11 @@
 pluginGroup = io.infracost.plugins
 pluginName = Infracost
-pluginVersion = 2.0.3
+pluginVersion = 2.0.4
 
 platformType = IU
 platformVersion = 2025.1
 
 pluginSinceBuild = 251
-pluginUntilBuild = 253.*
 
 kotlin.stdlib.default.dependency = false
 org.gradle.jvmargs = -Xmx2g


### PR DESCRIPTION
IDE capped at 2025 Q3 builds, not deprecation issues so can remove the cap
